### PR TITLE
Group processed projects by repository

### DIFF
--- a/src/components/ProcessedProjects.tsx
+++ b/src/components/ProcessedProjects.tsx
@@ -9,10 +9,19 @@ interface ProcessedProject {
   id: string;
   owner: string;
   repo: string;
+  ref: string;
   name: string;
   repo_type: string;
   submittedAt: number;
   language: string;
+}
+
+interface RepoGroup {
+  owner: string;
+  repo: string;
+  name: string;
+  repo_type: string;
+  refs: ProcessedProject[];
 }
 
 interface ProcessedProjectsProps {
@@ -22,17 +31,18 @@ interface ProcessedProjectsProps {
   messages?: Record<string, Record<string, string>>; // Translation messages with proper typing
 }
 
-export default function ProcessedProjects({ 
-  showHeader = true, 
-  maxItems, 
+export default function ProcessedProjects({
+  showHeader = true,
+  maxItems,
   className = "",
-  messages 
+  messages
 }: ProcessedProjectsProps) {
-  const [projects, setProjects] = useState<ProcessedProject[]>([]);
+  const [projectMap, setProjectMap] = useState<Record<string, RepoGroup>>({});
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [viewMode, setViewMode] = useState<'card' | 'list'>('card');
+  const [selectedRefs, setSelectedRefs] = useState<Record<string, string>>({});
 
   // Default messages fallback
   const defaultMessages = {
@@ -66,12 +76,37 @@ export default function ProcessedProjects({
         if (data.error) {
           throw new Error(data.error);
         }
-        setProjects(data as ProcessedProject[]);
+        const grouped = (data as ProcessedProject[]).reduce(
+          (acc, project) => {
+            const key = `${project.owner}/${project.repo}`;
+            if (!acc[key]) {
+              acc[key] = {
+                owner: project.owner,
+                repo: project.repo,
+                name: project.name,
+                repo_type: project.repo_type,
+                refs: [],
+              };
+            }
+            acc[key].refs.push(project);
+            return acc;
+          },
+          {} as Record<string, RepoGroup>
+        );
+        setProjectMap(grouped);
+        setSelectedRefs(() => {
+          const defaults: Record<string, string> = {};
+          for (const key in grouped) {
+            defaults[key] = grouped[key].refs[0]?.ref;
+          }
+          return defaults;
+        });
       } catch (e: unknown) {
         console.error("Failed to load projects from API:", e);
         const message = e instanceof Error ? e.message : "An unknown error occurred.";
         setError(message);
-        setProjects([]);
+        setProjectMap({});
+        setSelectedRefs({});
       } finally {
         setIsLoading(false);
       }
@@ -80,29 +115,32 @@ export default function ProcessedProjects({
     fetchProjects();
   }, []);
 
-  // Filter projects based on search query
-  const filteredProjects = useMemo(() => {
-    if (!searchQuery.trim()) {
-      return maxItems ? projects.slice(0, maxItems) : projects;
+  // Filter repos based on search query
+  const filteredRepos = useMemo(() => {
+    let repos = Object.values(projectMap);
+    if (searchQuery.trim()) {
+      const query = searchQuery.toLowerCase();
+      repos = repos.filter((repo) =>
+        repo.name.toLowerCase().includes(query) ||
+        repo.owner.toLowerCase().includes(query) ||
+        repo.repo.toLowerCase().includes(query) ||
+        repo.repo_type.toLowerCase().includes(query)
+      );
     }
-
-    const query = searchQuery.toLowerCase();
-    const filtered = projects.filter(project => 
-      project.name.toLowerCase().includes(query) ||
-      project.owner.toLowerCase().includes(query) ||
-      project.repo.toLowerCase().includes(query) ||
-      project.repo_type.toLowerCase().includes(query)
-    );
-
-    return maxItems ? filtered.slice(0, maxItems) : filtered;
-  }, [projects, searchQuery, maxItems]);
+    return maxItems ? repos.slice(0, maxItems) : repos;
+  }, [projectMap, searchQuery, maxItems]);
 
   const clearSearch = () => {
     setSearchQuery('');
   };
 
-  const handleDelete = async (project: ProcessedProject) => {
-    if (!confirm(`Are you sure you want to delete project ${project.name}?`)) {
+  const handleDelete = async (key: string) => {
+    const group = projectMap[key];
+    if (!group) return;
+    const selectedRef = selectedRefs[key] || group.refs[0]?.ref;
+    const project = group.refs.find((r) => r.ref === selectedRef);
+    if (!project) return;
+    if (!confirm(`Are you sure you want to delete project ${group.name} (${selectedRef})?`)) {
       return;
     }
     try {
@@ -110,17 +148,36 @@ export default function ProcessedProjects({
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          owner: project.owner,
-          repo: project.repo,
+          owner: group.owner,
+          repo: group.repo,
           repo_type: project.repo_type,
           language: project.language,
+          ref: project.ref,
         }),
       });
       if (!response.ok) {
         const errorBody = await response.json().catch(() => ({ error: response.statusText }));
         throw new Error(errorBody.error || response.statusText);
       }
-      setProjects(prev => prev.filter(p => p.id !== project.id));
+      setProjectMap((prev) => {
+        const newMap = { ...prev };
+        const repo = newMap[key];
+        if (!repo) return prev;
+        repo.refs = repo.refs.filter((r) => r.ref !== project.ref);
+        if (repo.refs.length === 0) {
+          delete newMap[key];
+        }
+        setSelectedRefs((sel) => {
+          const newSel = { ...sel };
+          if (newMap[key]) {
+            newSel[key] = newMap[key].refs[0]?.ref;
+          } else {
+            delete newSel[key];
+          }
+          return newSel;
+        });
+        return newMap;
+      });
     } catch (e: unknown) {
       console.error('Failed to delete project:', e);
       alert(`Failed to delete project: ${e instanceof Error ? e.message : 'Unknown error'}`);
@@ -191,78 +248,103 @@ export default function ProcessedProjects({
       {isLoading && <p className="text-[var(--muted)]">{t('loadingProjects')}</p>}
       {error && <p className="text-[var(--highlight)]">{t('errorLoading')} {error}</p>}
 
-      {!isLoading && !error && filteredProjects.length > 0 && (
+      {!isLoading && !error && filteredRepos.length > 0 && (
         <div className={viewMode === 'card' ? 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4' : 'space-y-2'}>
-            {filteredProjects.map((project) => (
-            viewMode === 'card' ? (
-              <div key={project.id} className="relative p-4 border border-[var(--border-color)] rounded-lg bg-[var(--card-bg)] shadow-sm hover:shadow-md transition-all duration-200 hover:scale-[1.02]">
+          {filteredRepos.map((repo) => {
+            const key = `${repo.owner}/${repo.repo}`;
+            const selectedRef = selectedRefs[key] || repo.refs[0]?.ref;
+            const selectedProject = repo.refs.find(r => r.ref === selectedRef) || repo.refs[0];
+            return viewMode === 'card' ? (
+              <div key={key} className="relative p-4 border border-[var(--border-color)] rounded-lg bg-[var(--card-bg)] shadow-sm hover:shadow-md transition-all duration-200 hover:scale-[1.02]">
                 <button
                   type="button"
-                  onClick={() => handleDelete(project)}
+                  onClick={() => handleDelete(key)}
                   className="absolute top-2 right-2 text-[var(--muted)] hover:text-[var(--foreground)]"
                   title="Delete project"
                 >
                   <FaTimes className="h-4 w-4" />
                 </button>
+                <div className="mb-2">
+                  <select
+                    value={selectedRef}
+                    onChange={(e) => setSelectedRefs(prev => ({ ...prev, [key]: e.target.value }))}
+                    className="w-full border border-[var(--border-color)] bg-[var(--background)] text-[var(--foreground)] rounded px-2 py-1 text-sm"
+                  >
+                    {repo.refs.map(r => (
+                      <option key={r.ref} value={r.ref}>{r.ref}</option>
+                    ))}
+                  </select>
+                </div>
                 <Link
-                  href={`/${project.owner}/${project.repo}?type=${project.repo_type}&language=${project.language}`}
+                  href={`/${repo.owner}/${repo.repo}?type=${selectedProject.repo_type}&language=${selectedProject.language}&ref=${selectedProject.ref}`}
                   className="block"
                 >
                   <h3 className="text-lg font-semibold text-[var(--link-color)] hover:underline mb-2 line-clamp-2">
-                    {project.name}
+                    {repo.name}
                   </h3>
                   <div className="flex flex-wrap gap-2 mb-3">
                     <span className="px-2 py-1 text-xs bg-[var(--accent-primary)]/10 text-[var(--accent-primary)] rounded-full border border-[var(--accent-primary)]/20">
-                      {project.repo_type}
+                      {selectedProject.repo_type}
                     </span>
                     <span className="px-2 py-1 text-xs bg-[var(--background)] text-[var(--muted)] rounded-full border border-[var(--border-color)]">
-                      {project.language}
+                      {selectedProject.language}
                     </span>
                   </div>
                   <p className="text-xs text-[var(--muted)]">
-                    {t('processedOn')} {new Date(project.submittedAt).toLocaleDateString()}
+                    {t('processedOn')} {new Date(selectedProject.submittedAt).toLocaleDateString()}
                   </p>
                 </Link>
               </div>
             ) : (
-              <div key={project.id} className="relative p-3 border border-[var(--border-color)] rounded-lg bg-[var(--card-bg)] hover:bg-[var(--background)] transition-colors">
+              <div key={key} className="relative p-3 border border-[var(--border-color)] rounded-lg bg-[var(--card-bg)] hover:bg-[var(--background)] transition-colors">
                 <button
                   type="button"
-                  onClick={() => handleDelete(project)}
+                  onClick={() => handleDelete(key)}
                   className="absolute top-2 right-2 text-[var(--muted)] hover:text-[var(--foreground)]"
                   title="Delete project"
                 >
                   <FaTimes className="h-4 w-4" />
                 </button>
+                <div className="mb-2">
+                  <select
+                    value={selectedRef}
+                    onChange={(e) => setSelectedRefs(prev => ({ ...prev, [key]: e.target.value }))}
+                    className="border border-[var(--border-color)] bg-[var(--background)] text-[var(--foreground)] rounded px-2 py-1 text-sm"
+                  >
+                    {repo.refs.map(r => (
+                      <option key={r.ref} value={r.ref}>{r.ref}</option>
+                    ))}
+                  </select>
+                </div>
                 <Link
-                  href={`/${project.owner}/${project.repo}?type=${project.repo_type}&language=${project.language}`}
+                  href={`/${repo.owner}/${repo.repo}?type=${selectedProject.repo_type}&language=${selectedProject.language}&ref=${selectedProject.ref}`}
                   className="flex items-center justify-between"
                 >
                   <div className="flex-1 min-w-0">
                     <h3 className="text-base font-medium text-[var(--link-color)] hover:underline truncate">
-                      {project.name}
+                      {repo.name}
                     </h3>
                     <p className="text-xs text-[var(--muted)] mt-1">
-                      {t('processedOn')} {new Date(project.submittedAt).toLocaleDateString()} • {project.repo_type} • {project.language}
+                      {t('processedOn')} {new Date(selectedProject.submittedAt).toLocaleDateString()} • {selectedProject.repo_type} • {selectedProject.language}
                     </p>
                   </div>
                   <div className="flex gap-2 ml-4">
                     <span className="px-2 py-1 text-xs bg-[var(--accent-primary)]/10 text-[var(--accent-primary)] rounded border border-[var(--accent-primary)]/20">
-                      {project.repo_type}
+                      {selectedProject.repo_type}
                     </span>
                   </div>
                 </Link>
               </div>
-            )
-          ))}
+            );
+          })}
         </div>
       )}
 
-      {!isLoading && !error && projects.length > 0 && filteredProjects.length === 0 && searchQuery && (
+      {!isLoading && !error && Object.keys(projectMap).length > 0 && filteredRepos.length === 0 && searchQuery && (
         <p className="text-[var(--muted)]">{t('noSearchResults')}</p>
       )}
 
-      {!isLoading && !error && projects.length === 0 && (
+      {!isLoading && !error && Object.keys(projectMap).length === 0 && (
         <p className="text-[var(--muted)]">{t('noProjects')}</p>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Map fetched projects by `owner/repo` and track refs per repository
- Render a ref selector and link cards to the chosen ref
- Delete the selected ref and update repository listings accordingly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689518cff7e48321b9b67a7046bb7be2